### PR TITLE
Fetch secondary synonyms

### DIFF
--- a/src/Components/App/App.svelte
+++ b/src/Components/App/App.svelte
@@ -5,14 +5,17 @@
 	
 	let synonyms = []
 	let originalWord = ''
+	let loading = false
 
 	const getSynonyms = (e) => {
 		originalWord = e.detail
+		loading = true
 		fetch(
 		 `https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${originalWord}?key=67f08311-bb1f-477c-bd38-cc6dfb68104d`
 		)
 		.then(res => res.json())
 		.then(data => synonyms = data[0].meta.syns[0])
+		.then(res => loading = false)
 		.catch(err => console.log(err))
 	}
  </script>
@@ -27,6 +30,9 @@
 	/>
  {:else}
  <p>Search for a word to view synonyms</p>
+ {/if}
+ {#if loading}
+ <p>loading</p>
  {/if}
  </main>
 	

--- a/src/Components/App/App.svelte
+++ b/src/Components/App/App.svelte
@@ -32,7 +32,7 @@
  <p>Search for a word to view synonyms</p>
  {/if}
  {#if loading}
- <p>loading</p>
+ <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
  {/if}
  </main>
 	
@@ -47,6 +47,92 @@
 		font-family: 'Quicksand';
 		font-size: xx-large;
 	}
+
+	.lds-roller {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+.lds-roller div {
+  animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  transform-origin: 40px 40px;
+}
+.lds-roller div:after {
+  content: " ";
+  display: block;
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #cef;
+  margin: -4px 0 0 -4px;
+}
+.lds-roller div:nth-child(1) {
+  animation-delay: -0.036s;
+}
+.lds-roller div:nth-child(1):after {
+  top: 63px;
+  left: 63px;
+}
+.lds-roller div:nth-child(2) {
+  animation-delay: -0.072s;
+}
+.lds-roller div:nth-child(2):after {
+  top: 68px;
+  left: 56px;
+}
+.lds-roller div:nth-child(3) {
+  animation-delay: -0.108s;
+}
+.lds-roller div:nth-child(3):after {
+  top: 71px;
+  left: 48px;
+}
+.lds-roller div:nth-child(4) {
+  animation-delay: -0.144s;
+}
+.lds-roller div:nth-child(4):after {
+  top: 72px;
+  left: 40px;
+}
+.lds-roller div:nth-child(5) {
+  animation-delay: -0.18s;
+}
+.lds-roller div:nth-child(5):after {
+  top: 71px;
+  left: 32px;
+}
+.lds-roller div:nth-child(6) {
+  animation-delay: -0.216s;
+}
+.lds-roller div:nth-child(6):after {
+  top: 68px;
+  left: 24px;
+}
+.lds-roller div:nth-child(7) {
+  animation-delay: -0.252s;
+}
+.lds-roller div:nth-child(7):after {
+  top: 63px;
+  left: 17px;
+}
+.lds-roller div:nth-child(8) {
+  animation-delay: -0.288s;
+}
+.lds-roller div:nth-child(8):after {
+  top: 56px;
+  left: 12px;
+}
+@keyframes lds-roller {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 	@media (min-width: 640px) {
 		main {
 			max-width: none;

--- a/src/Components/App/App.svelte
+++ b/src/Components/App/App.svelte
@@ -21,7 +21,10 @@
  <Header />
  <Form on:submitword={getSynonyms}/>
  {#if synonyms.length}
- <SynonymContainer originalWord={originalWord} synonyms={synonyms}/>
+ <SynonymContainer 
+		originalWord={originalWord} 
+		synonyms={synonyms}
+	/>
  {:else}
  <p>Search for a word to view synonyms</p>
  {/if}

--- a/src/Components/Synonym/Synonym.svelte
+++ b/src/Components/Synonym/Synonym.svelte
@@ -1,8 +1,15 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
   export let word
+
+  const clickHandler = e => {
+    e.preventDefault();
+    dispatch('getsecondarysynonyms', word)
+  }
 </script>
 
-<div>
+<div on:click={clickHandler}>
   <p>{word}</p>
 </div>
 

--- a/src/Components/SynonymContainer/SynonymContainer.svelte
+++ b/src/Components/SynonymContainer/SynonymContainer.svelte
@@ -30,7 +30,7 @@
     flex-flow: row wrap;
     overflow: auto;
   }
-  h3 {
+  h2 {
     font-family: 'Quicksand';
   }
 

--- a/src/Components/SynonymContainer/SynonymContainer.svelte
+++ b/src/Components/SynonymContainer/SynonymContainer.svelte
@@ -2,12 +2,23 @@
   import Synonym from '../Synonym/Synonym.svelte';
   export let synonyms
   export let originalWord
+
+  const getSynonyms = (e) => {
+		originalWord = e.detail
+		fetch(
+		 `https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${originalWord}?key=67f08311-bb1f-477c-bd38-cc6dfb68104d`
+		)
+		.then(res => res.json())
+		.then(data => synonyms = data[0].meta.syns[0])
+		.catch(err => console.log(err))
+	}
 </script>
 
 <h2>Synonyms for {originalWord}</h2> 
 <div class="container">
   {#each synonyms as word}
   <Synonym 
+    on:getsecondarysynonyms={getSynonyms}
     word={word}
   />
   {/each}


### PR DESCRIPTION
#### What's this PR do?
- adds the secondary fetch when a user clicks on a synonym
#### Where should the reviewer start?
- SynonymContainer is where the second fetch lives
#### How should this be manually tested?
- Click through the app and watch the changes
#### Any background context you want to provide?
- Currently using duplicate fetch. I attempted to pull the fetch call out into its own file so that I could use it in two places, but ran into some trouble. Instead, I just duplicated the fetch call inside of the synonymContainer. I'll open an issue to refactor this and DRY it up.
#### What are the relevant tickets?
- closes #4 
#### Screenshots (if appropriate)
![Mar-02-2020 12-20-13](https://user-images.githubusercontent.com/49926352/75709613-4156d380-5c80-11ea-835b-cb5a43f8b13f.gif)
